### PR TITLE
Fix use-after-free on flush failure by avoiding context destroy on retry

### DIFF
--- a/plugins/out_oracle_log_analytics/oci_logan.c
+++ b/plugins/out_oracle_log_analytics/oci_logan.c
@@ -1199,7 +1199,7 @@ static void cb_oci_logan_flush(struct flb_event_chunk *event_chunk,
                       ins, out_context,
                       config);
     if (ret != FLB_OK) {
-        flb_oci_logan_conf_destroy(ctx);
+        flb_plg_error(ctx->ins, "flush failed with code %d", ret);
         FLB_OUTPUT_RETURN(ret);
     }
     flb_plg_debug(ctx->ins, "success");


### PR DESCRIPTION
This pull request includes a change to the `cb_oci_logan_flush` function in the `plugins/out_oracle_log_analytics/oci_logan.c` file. The change replaces the call to `flb_oci_logan_conf_destroy` with an error logging statement to provide more detailed error information when the flush operation fails.

* [`plugins/out_oracle_log_analytics/oci_logan.c`](diffhunk://#diff-81a068290e9bdd10163cce2b30b61dff7aee9f6ca351196d473d03cbd6d8ead5L1202-R1202): Replaced `flb_oci_logan_conf_destroy` with `flb_plg_error` to log the error code when the flush operation fails.