### PR TITLE
Oracle plugin dev

### DIFF
--- a/plugins/out_oracle_log_analytics/oci_logan.c
+++ b/plugins/out_oracle_log_analytics/oci_logan.c
@@ -1199,7 +1199,6 @@ static void cb_oci_logan_flush(struct flb_event_chunk *event_chunk,
                       ins, out_context,
                       config);
     if (ret != FLB_OK) {
-        flb_oci_logan_conf_destroy(ctx);
         FLB_OUTPUT_RETURN(ret);
     }
     flb_plg_debug(ctx->ins, "success");

--- a/plugins/out_oracle_log_analytics/oci_logan.c
+++ b/plugins/out_oracle_log_analytics/oci_logan.c
@@ -39,6 +39,7 @@
 #include "oci_logan.h"
 
 
+
 static int check_config_from_record(msgpack_object key,
                                    char *name, int len)
 {
@@ -1217,6 +1218,11 @@ static int cb_oci_logan_exit(void *data, struct flb_config *config)
 
 /* Configuration properties map */
 static struct flb_config_map config_map[] = {
+    {
+        FLB_CONFIG_MAP_STR, "auth_mode", "config_file",
+        0, FLB_TRUE, offsetof(struct flb_oci_logan, auth_mode),
+        "Authentication mode : config_file as default or instance_principal"
+    },
     {
         FLB_CONFIG_MAP_STR, "config_file_location", "",
         0, FLB_TRUE, offsetof(struct flb_oci_logan, config_file_location),

--- a/plugins/out_oracle_log_analytics/oci_logan.h
+++ b/plugins/out_oracle_log_analytics/oci_logan.h
@@ -156,6 +156,24 @@
 #include <fluent-bit/flb_hash_table.h>
 #include <monkey/mk_core/mk_list.h>
 
+
+//!added by @rghouzra
+//?to be tested
+
+#define METADATA_BASE_URL "http://169.254.169.254/opc/v2"
+#define AUTH_HEADER "Authorization: Bearer Oracle"
+#define CERT_FILE "/tmp/flb_oci_leaf_cert.pem"
+#define KEY_FILE "/tmp/flb_oci_leaf_key.pem"
+#define INTERMEDIATE_CERT_FILE "/tmp/flb_oci_intermediate_cert.pem"
+#define TOKEN_FILE "/tmp/flb_oci_token.json"
+
+
+struct oci_instance_principal_provider{
+  char *token;
+};
+
+
+
 struct metadata_obj {
     flb_sds_t key;
     flb_sds_t val;
@@ -198,6 +216,11 @@ struct flb_oci_logan {
     struct mk_list global_metadata_fields;
     struct mk_list *oci_la_metadata;
     struct mk_list log_event_metadata_fields;
+
+  // auth mode
+    char *auth_mode;
+  // instance principal
+
 
   // config_file
     flb_sds_t user;

--- a/plugins/out_oracle_log_analytics/oci_logan_conf.c
+++ b/plugins/out_oracle_log_analytics/oci_logan_conf.c
@@ -373,14 +373,18 @@ struct flb_oci_logan *flb_oci_logan_conf_create(struct flb_output_instance *ins,
 
 
     /* Check if SSL/TLS is enabled */
-    io_flags = FLB_IO_TCP;
-    default_port = 80;
-
 #ifdef FLB_HAVE_TLS
     if (ins->use_tls == FLB_TRUE) {
         io_flags = FLB_IO_TLS;
         default_port = 443;
     }
+    else {
+        flb_plg_error(ctx->ins, "TLS must be enabled, for OCI");
+        return NULL;
+    }
+#else
+    flb_plg_error(ctx->ins, "TLS support required for for OCI");
+    return NULL;
 #endif
 
     if (ins->host.ipv6 == FLB_TRUE) {

--- a/plugins/out_oracle_log_analytics/oci_logan_conf.c
+++ b/plugins/out_oracle_log_analytics/oci_logan_conf.c
@@ -45,7 +45,6 @@ static int create_pk_context(flb_sds_t filepath, const char *key_passphrase,
     FILE *fp;
     flb_sds_t kbuffer;
 
-
     ret = stat(filepath, &st);
     if (ret == -1) {
         flb_errno();
@@ -284,10 +283,17 @@ struct flb_oci_logan *flb_oci_logan_conf_create(struct flb_output_instance *ins,
     mk_list_init(&ctx->log_event_metadata_fields);
 
     ctx->ins = ins;
-
+    
     ret = flb_output_config_map_set(ins, (void *) ctx);
     if (ret == -1) {
         flb_plg_error(ctx->ins, "configuration error");
+        flb_oci_logan_conf_destroy(ctx);
+        return NULL;
+    }
+
+    if(strcmp (ctx->auth_mode, "instance_principal") == 0){
+        // get certs and keys
+        flb_plg_error(ctx->ins, "instance principal authentication still not available");
         flb_oci_logan_conf_destroy(ctx);
         return NULL;
     }


### PR DESCRIPTION
This pull request involve adding new configuration options, handling authentication modes, and enforcing TLS requirements.

### Authentication Enhancements:
* Added a new configuration option, `auth_mode`, with a default value of `"config_file"`. This allows users to specify the authentication mode, including support for "instance principal" authentication(still not implemented). (`[plugins/out_oracle_log_analytics/oci_logan.cR1221-R1225](diffhunk://#diff-81a068290e9bdd10163cce2b30b61dff7aee9f6ca351196d473d03cbd6d8ead5R1221-R1225)`)


### TLS Requirements:
* Enforced TLS support by adding checks to ensure that TLS is enabled for Oracle Cloud Infrastructure (OCI) connections. If TLS is not enabled, an error is logged, and the plugin initialization fails. (`[plugins/out_oracle_log_analytics/oci_logan_conf.cL376-R393](diffhunk://#diff-a058dc45731909d76394577c3539777b088a2dc9f16057946bc5675fc2ed783aL376-R393)`)
